### PR TITLE
Android object might not be initialized.

### DIFF
--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -134,9 +134,9 @@ export class DropDown extends common.DropDown
     public _onSelectedIndexPropertyChanged(data: dependencyObservable.PropertyChangeData)
     {
         super._onSelectedIndexPropertyChanged(data);
-		if(this.android) {
-			this.android.setSelection(data.newValue);
-		}
+        if (this.android) {
+           this.android.setSelection(data.newValue);
+        }
     }
 
     private _updateSelectedIndexOnItemsPropertyChanged(newItems)

--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -134,7 +134,9 @@ export class DropDown extends common.DropDown
     public _onSelectedIndexPropertyChanged(data: dependencyObservable.PropertyChangeData)
     {
         super._onSelectedIndexPropertyChanged(data);
-        this.android.setSelection(data.newValue);
+		if(this.android) {
+			this.android.setSelection(data.newValue);
+		}
     }
 
     private _updateSelectedIndexOnItemsPropertyChanged(newItems)


### PR DESCRIPTION
Android object is not initialized the first time, when used with nativescript-angular. Preventing the invalid access to the android object fixes initialization. Setting the initial value does work