### PR TITLE
Support binding items to array of objects with a DisplayValue property

### DIFF
--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -186,7 +186,7 @@ class DropDownAdapter extends android.widget.BaseAdapter
             && i < this._dropDown.items.length
             )
         {
-            if(typeof (this._dropDown.items.getItem ? this._dropDown.items.getItem(i) : this._dropDown.items[i]) === "object") {
+            if (typeof (this._dropDown.items.getItem ? this._dropDown.items.getItem(i) : this._dropDown.items[i]) === "object") {
                 return this._dropDown.items.getItem ? this._dropDown.items.getItem(i).DisplayValue : this._dropDown.items[i].DisplayValue;
             }
             else {

--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -186,7 +186,12 @@ class DropDownAdapter extends android.widget.BaseAdapter
             && i < this._dropDown.items.length
             )
         {
-            return this._dropDown.items.getItem ? this._dropDown.items.getItem(i) : this._dropDown.items[i];
+            if(typeof (this._dropDown.items.getItem ? this._dropDown.items.getItem(i) : this._dropDown.items[i]) === "object") {
+                return this._dropDown.items.getItem ? this._dropDown.items.getItem(i).DisplayValue : this._dropDown.items[i].DisplayValue;
+            }
+            else {
+                return this._dropDown.items.getItem ? this._dropDown.items.getItem(i) : this._dropDown.items[i];
+            }
         }
 
         return null;

--- a/drop-down.ios.ts
+++ b/drop-down.ios.ts
@@ -119,7 +119,12 @@ export class DropDown extends common.DropDown
     {
         super._onSelectedIndexPropertyChanged(data);
         this._listPicker.selectedIndex = data.newValue;
-        this._textField.text = (this.items && this.items.getItem ? this.items.getItem(data.newValue) : this.items[data.newValue]);
+        if(typeof (this.items && this.items.getItem ? this.items.getItem(data.newValue) : this.items[data.newValue]) === "object") {
+            this._textField.text = (this.items && this.items.getItem ? this.items.getItem(data.newValue).DisplayValue : this.items[data.newValue].DisplayValue);
+        }
+        else {
+            this._textField.text = (this.items && this.items.getItem ? this.items.getItem(data.newValue) : this.items[data.newValue]);
+        }
     }
 }
 

--- a/drop-down.ios.ts
+++ b/drop-down.ios.ts
@@ -119,7 +119,7 @@ export class DropDown extends common.DropDown
     {
         super._onSelectedIndexPropertyChanged(data);
         this._listPicker.selectedIndex = data.newValue;
-        if(typeof (this.items && this.items.getItem ? this.items.getItem(data.newValue) : this.items[data.newValue]) === "object") {
+        if (typeof (this.items && this.items.getItem ? this.items.getItem(data.newValue) : this.items[data.newValue]) === "object") {
             this._textField.text = (this.items && this.items.getItem ? this.items.getItem(data.newValue).DisplayValue : this.items[data.newValue].DisplayValue);
         }
         else {


### PR DESCRIPTION
This would support the use of an array of objects to be used for the drop down. While still only displaying a single string value for the widget, the selected index could be used to identify an object in the array.

This is also backward compatible, so existing code that uses this plugin should not break.