### PR TITLE
Fix __extends on webpack bundle issue

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -31,6 +31,7 @@
                     module: "commonjs",
                     declaration: false,
                     noImplicitAny: false,
+                    noEmitHelpers: true,
                     removeComments: true,
                     sourceMap: false,
                     noLib: false,


### PR DESCRIPTION
Hi, it seems your `gruntfile.js` is not reading your `tconfig.json`, so I added a very important option(noEmitHelpers) to be able to run while bundling with webpack.

You can read more about here: https://github.com/NativeScript/nativescript-dev-webpack/issues/8#issuecomment-233526850

That would be nice if you could also run a new build and update the npm after this PR.

Thanks