### PR TITLE
Fix to avoid angular compiler.es5.js getting bundled in AOT enabled webpack builds

### DIFF
--- a/angular/index.ts
+++ b/angular/index.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Directive, ElementRef, HostListener, Inject, NgModule, forwardRef } from "@angular/core";
 import { FormsModule, NG_VALUE_ACCESSOR } from "@angular/forms";
-import { BaseValueAccessor, registerElement } from "nativescript-angular";
+import { registerElement } from "nativescript-angular/element-registry";
+import { BaseValueAccessor } from "nativescript-angular/value-accessors/base-value-accessor";
 import { View } from "tns-core-modules/ui/core/view";
 
 registerElement("DropDown", () => require("../drop-down").DropDown);


### PR DESCRIPTION
Currently when we use this plugin and if we prepare AOT build using `nativescript-dev-webpack` plugin, I found that `@angular/compiler/@angular/compiler.es5.js`  (size: ~966KB) is also getting bundled in `bundle.js`. Ideally this file should not get bundled in AOT builds.

I tried to find the root cause using webpack analyze tool and found that it is getting included because of below line:

`nativescript-drop-down/angular/index.ts`
```
import { BaseValueAccessor, registerElement } from "nativescript-angular";
```

This `nativescript-angular` modules is requiring `nativescript-angular/platform` and that is importing `@angular/compiler`.

When I changed the above import line to as shown below, the final build did not included the `compiler.es5.js`, resulting in smaller and faster build compared to before.

```
import { registerElement } from "nativescript-angular/element-registry";
import { BaseValueAccessor } from "nativescript-angular/value-accessors/base-value-accessor";
```

If you find this proper, then please apply this change. Let me know in case of any issues/concerns.

Thanks.
