### PR TITLE
Feature/multi styles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,10 +3,9 @@
     "files.exclude": {
         "**/.git": true,
         "**/.DS_Store": true,
-        // "demo": true,
-        // "demo-ng": true,
+        "demo": true,
+        "demo-ng": true,
         "bin/**": true
     },
-    "editor.formatOnSave": false,
     "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,11 @@
 {
     "files.exclude": {
         "**/.git": true,
-        "**/.DS_Store": true, 
-        "demo": true, 
-        "demo-ng": true, 
+        "**/.DS_Store": true,
+        // "demo": true,
+        // "demo-ng": true,
         "bin/**": true
     },
+    "editor.formatOnSave": false,
     "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/angular/index.ts
+++ b/angular/index.ts
@@ -5,6 +5,7 @@ import { BaseValueAccessor } from "nativescript-angular/forms/value-accessors/ba
 import { View } from "tns-core-modules/ui/core/view";
 
 registerElement("DropDown", () => require("../drop-down").DropDown);
+registerElement("DropDownList", () => require("../drop-down").DropDownList);
 
 const SELECTED_INDEX_VALUE_ACCESSOR = {provide: NG_VALUE_ACCESSOR,
     useExisting: forwardRef(() => SelectedIndexValueAccessor), multi: true};

--- a/demo/app/app.css
+++ b/demo/app/app.css
@@ -26,3 +26,8 @@
 StackLayout {
     horizontal-align: center;
 }
+
+DropDownList {
+    color: blue;
+    text-align: right;
+}

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -3,7 +3,9 @@
     <dd:DropDown id="dd" hint="{{ hint }}" items="{{ items }}" selectedIndex="{{ selectedIndex }}" 
                   opened="dropDownOpened" closed="dropDownClosed" selectedIndexChanged="dropDownSelectedIndexChanged" 
                   class="{{ cssClass }}" isEnabled="{{ isEnabled }}"
-                  row="0" colSpan="2" /> 
+                  row="0" colSpan="2">
+      <dd:DropDownList style="color: blue; text-align: right;"></dd:DropDownList>
+    </dd:DropDown> 
 
     <Label text="Selected Index:" row="1" col="0" fontSize="18" verticalAlignment="bottom"/>
     <TextField text="{{ selectedIndex }}" row="1" col="1" />

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -4,7 +4,6 @@
                   opened="dropDownOpened" closed="dropDownClosed" selectedIndexChanged="dropDownSelectedIndexChanged" 
                   class="{{ cssClass }}" isEnabled="{{ isEnabled }}"
                   row="0" colSpan="2">
-      <dd:DropDownList style="color: blue; text-align: right;"></dd:DropDownList>
     </dd:DropDown> 
 
     <Label text="Selected Index:" row="1" col="0" fontSize="18" verticalAlignment="bottom"/>

--- a/drop-down-common.ts
+++ b/drop-down-common.ts
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
 import { ObservableArray } from "data/observable-array";
-import { AddChildFromBuilder, CSSType, CoercibleProperty, EventData, Property, View } from "ui/core/view";
+import { CSSType, CoercibleProperty, EventData, Property } from "ui/core/view";
 import { addWeakEventListener, removeWeakEventListener } from "ui/core/weak-event-listener";
+import { LayoutBase } from "ui/layouts/layout-base";
 import { ItemsSource } from "ui/list-picker";
 import { Style } from "ui/styling/style";
 import { TextBase } from "ui/text-base";
@@ -30,7 +31,7 @@ export class DropDownList extends TextBase {
 }
 
 @CSSType("DropDown")
-export abstract class DropDownBase extends View implements DropDownDefinition, AddChildFromBuilder {
+export abstract class DropDownBase extends LayoutBase implements DropDownDefinition {
     public static openedEvent = "opened";
     public static closedEvent = "closed";
     public static selectedIndexChangedEvent = "selectedIndexChanged";
@@ -43,19 +44,19 @@ export abstract class DropDownBase extends View implements DropDownDefinition, A
     public isItemsSourceIn: boolean;
     public isValueListIn: boolean;
 
+    constructor() {
+        super();
+
+        this.dropDownList = new DropDownList();
+        this.addChild(this.dropDownList);
+    }
+
     public abstract open();
     public abstract close();
     public abstract refresh();
-
     public _getDropDownStyle(): Style | void {
         if (this.dropDownList) {
             return this.dropDownList.style;
-        }
-    }
-
-    public _addChildFromBuilder(name: string, value: any): void {
-        if (name === "DropDownList") {
-            this.dropDownList = value;
         }
     }
 

--- a/drop-down-common.ts
+++ b/drop-down-common.ts
@@ -36,7 +36,6 @@ export abstract class DropDownBase extends LayoutBase implements DropDownDefinit
     public static closedEvent = "closed";
     public static selectedIndexChangedEvent = "selectedIndexChanged";
 
-    public dropDownList: DropDownList;
     public hint: string;
     public selectedIndex: number;
     public items: any[] | ItemsSource;
@@ -44,6 +43,8 @@ export abstract class DropDownBase extends LayoutBase implements DropDownDefinit
     public isItemsSourceIn: boolean;
     public isValueListIn: boolean;
 
+    private dropDownList: DropDownList;
+    
     constructor() {
         super();
 

--- a/drop-down-common.ts
+++ b/drop-down-common.ts
@@ -18,97 +18,15 @@ import { AddChildFromBuilder, CSSType, CoercibleProperty, EventData, Property, V
 import { addWeakEventListener, removeWeakEventListener } from "ui/core/weak-event-listener";
 import { ItemsSource } from "ui/list-picker";
 import { Style } from "ui/styling/style";
-import { Color, Length, TextAlignment, TextBase, TextDecoration, TextTransform, letterSpacingProperty, paddingBottomProperty, paddingLeftProperty, paddingRightProperty, paddingTopProperty, textAlignmentProperty, textDecorationProperty, textTransformProperty } from "ui/text-base";
+import { TextBase } from "ui/text-base";
 import * as types from "utils/types";
 import { DropDown as DropDownDefinition, SelectedIndexChangedEventData, ValueItem, ValueList as ValueListDefinition } from ".";
 
-import { Font } from "tns-core-modules/ui/styling/font";
-import {backgroundColorProperty, colorProperty, fontInternalProperty, layout} from "ui/core/view";
 export * from "ui/core/view";
 
 @CSSType("DropDownList")
-export class DropDownListBase extends TextBase {
+export class DropDownList extends TextBase {
     
-    public [colorProperty.getDefault](): UIColor {
-        return this.nativeView.color;
-    }
-    public [colorProperty.setNative](value: Color | UIColor) {
-        const color = value instanceof Color ? value.ios : value;
-
-        this.nativeView.color = color;
-    }
-
-    public [backgroundColorProperty.getDefault](): UIColor {
-        return this.nativeView.backgroundColor;
-    }
-    public [backgroundColorProperty.setNative](value: Color | UIColor) {
-        if (!value) {
-            return;
-        }
-        
-        const color = value instanceof Color ? value.ios : value;
-        
-        this.nativeView.backgroundColor = color;
-    }
-
-    public [fontInternalProperty.getDefault](): UIFont {
-        return this.nativeView.font;
-    }
-    public [fontInternalProperty.setNative](value: Font | UIFont) {
-        const font = value instanceof Font ? value.getUIFont(this.nativeView.font) : value;
-        this.nativeView.font = font;
-    }
-
-    public [textAlignmentProperty.setNative](value: TextAlignment) {
-        switch (value) {
-            case "initial":
-            case "left":
-                this.nativeView.textAlignment = NSTextAlignment.Left;
-                break;
-
-            case "center":
-                this.nativeView.textAlignment = NSTextAlignment.Center;
-                break;
-
-            case "right":
-                this.nativeView.textAlignment = NSTextAlignment.Right;
-                break;
-        }
-    }
-
-    public [textDecorationProperty.setNative](value: TextDecoration) {
-        _setTextAttributes(this.nativeView, this.style);
-    }
-
-    public [textTransformProperty.setNative](value: TextTransform) {
-        _setTextAttributes(this.nativeView, this.style);
-    }
-
-    public [letterSpacingProperty.setNative](value: number) {
-        _setTextAttributes(this.nativeView, this.style);
-    }
-
-    public [paddingTopProperty.setNative](value: Length) {
-        this._setPadding({ top: layout.toDeviceIndependentPixels(this.effectivePaddingTop) });
-    }
-
-    public [paddingRightProperty.setNative](value: Length) {
-        this._setPadding({ right: layout.toDeviceIndependentPixels(this.effectivePaddingRight) });
-    }
-
-    public [paddingBottomProperty.setNative](value: Length) {
-        this._setPadding({ bottom: layout.toDeviceIndependentPixels(this.effectivePaddingBottom) });
-    }
-
-    public [paddingLeftProperty.setNative](value: Length) {
-        this._setPadding({ left: layout.toDeviceIndependentPixels(this.effectivePaddingLeft) });
-    }
-
-    private _setPadding(newPadding: { top?: number, right?: number, bottom?: number, left?: number }) {
-        const nativeView = this.nativeView;
-        const padding = nativeView.padding;
-        nativeView.padding = Object.assign(padding, newPadding);
-    }
 }
 
 @CSSType("DropDown")
@@ -117,7 +35,7 @@ export abstract class DropDownBase extends View implements DropDownDefinition, A
     public static closedEvent = "closed";
     public static selectedIndexChangedEvent = "selectedIndexChanged";
 
-    public dropDownList: DropDownListBase;
+    public dropDownList: DropDownList;
     public hint: string;
     public selectedIndex: number;
     public items: any[] | ItemsSource;
@@ -257,63 +175,3 @@ export const hintProperty = new Property<DropDownBase, string>({
     defaultValue: ""
 });
 hintProperty.register(DropDownBase);
-
-function _setTextAttributes(nativeView: TNSLabel, style: Style) {
-    const attributes = new Map<string, any>();
-
-    switch (style.textDecoration) {
-        case "none":
-            break;
-
-        case "underline":
-            attributes.set(NSUnderlineStyleAttributeName, NSUnderlineStyle.StyleSingle);
-            break;
-
-        case "line-through":
-            attributes.set(NSStrikethroughStyleAttributeName, NSUnderlineStyle.StyleSingle);
-            break;
-
-        case "underline line-through":
-            attributes.set(NSUnderlineStyleAttributeName, NSUnderlineStyle.StyleSingle);
-            attributes.set(NSStrikethroughStyleAttributeName, NSUnderlineStyle.StyleSingle);
-            break;
-    }
-
-    if (style.letterSpacing !== 0) {
-        attributes.set(NSKernAttributeName, style.letterSpacing * nativeView.font.pointSize);
-    }
-
-    if (nativeView.textColor && attributes.size > 0) {
-        attributes.set(NSForegroundColorAttributeName, nativeView.textColor);
-    }
-
-    const text: string = types.isNullOrUndefined(nativeView.text) ? "" : nativeView.text.toString();
-    let sourceString: string;
-    switch (style.textTransform) {
-        case "uppercase":
-            sourceString = NSString.stringWithString(text).uppercaseString;
-            break;
-
-        case "lowercase":
-            sourceString = NSString.stringWithString(text).lowercaseString;
-            break;
-
-        case "capitalize":
-            sourceString = NSString.stringWithString(text).capitalizedString;
-            break;
-
-        default:
-            sourceString = text;
-    }
-
-    if (attributes.size > 0) {
-        const result = NSMutableAttributedString.alloc().initWithString(sourceString);
-        result.setAttributesRange(attributes as any, { location: 0, length: sourceString.length });
-        nativeView.attributedText = result;
-    }
-    else {
-        // Clear attributedText or text won't be affected.
-        nativeView.attributedText = undefined;
-        nativeView.text = sourceString;
-    }
-}

--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -20,6 +20,7 @@ import { StackLayout } from "ui/layouts/stack-layout";
 import { ItemsSource } from "ui/list-picker";
 import { Font } from "ui/styling/font";
 import {
+    Style,
     TextAlignment,
     TextDecoration,
     fontInternalProperty,
@@ -69,7 +70,6 @@ export class DropDown extends DropDownBase {
         const adapter = new DropDownAdapter(new WeakRef(this));
         spinner.setAdapter(adapter);
         spinner.adapter = adapter;
-
         initializeDropDownItemSelectedListener();
         const itemSelectedListener = new DropDownItemSelectedListener(new WeakRef(this));
         spinner.setOnItemSelectedListener(itemSelectedListener);
@@ -365,14 +365,14 @@ function initializeDropDownAdapter() {
         }
 
         public getView(index: number, convertView: android.view.View, parent: android.view.ViewGroup): android.view.View {
-            return this._generateView(index, convertView, parent, RealizedViewType.ItemView);
+            return this._generateView(index, convertView, parent, RealizedViewType.ItemView, this.owner.get().style);
         }
 
         public getDropDownView(index: number, convertView: android.view.View, parent: android.view.ViewGroup): android.view.View {
-            return this._generateView(index, convertView, parent, RealizedViewType.DropDownView);
+            return this._generateView(index, convertView, parent, RealizedViewType.DropDownView, this.owner.get()._getDropDownStyle());
         }
 
-        private _generateView(index: number, convertView: android.view.View, parent: android.view.ViewGroup, realizedViewType: RealizedViewType): android.view.View {
+        private _generateView(index: number, convertView: android.view.View, parent: android.view.ViewGroup, realizedViewType: RealizedViewType, style: Style | void): android.view.View {
             // In some strange situations owner can become null (see #181)
             if (!this.owner) {
                 return null;
@@ -395,22 +395,27 @@ function initializeDropDownAdapter() {
                 const label = view.getViewById<Label>(LABELVIEWID);
                 label.text = this.getItem(index);
 
+                if (!style) {
+                    owner._realizedItems[realizedViewType].set(convertView, view);
+                    return convertView;
+                }
+
                 // Copy root styles to view
-                if (owner.style.color) {
-                    label.style.color = owner.style.color;
+                if (style.color) {
+                    label.style.color = style.color;
                 }
-                label.style.textDecoration = owner.style.textDecoration;
-                label.style.textAlignment = owner.style.textAlignment;
-                label.style.fontInternal = owner.style.fontInternal;
-                if (owner.style.fontSize) {
-                    label.style.fontSize = owner.style.fontSize;
+                label.style.textDecoration = style.textDecoration;
+                label.style.textAlignment = style.textAlignment;
+                label.style.fontInternal = style.fontInternal;
+                if (style.fontSize) {
+                    label.style.fontSize = style.fontSize;
                 }
-                view.style.backgroundColor = owner.style.backgroundColor;
-                view.style.padding = owner.style.padding;
-                view.style.height = owner.style.height;
+                view.style.backgroundColor = style.backgroundColor;
+                view.style.padding = style.padding;
+                view.style.height = style.height;
 
                 if (realizedViewType === RealizedViewType.DropDownView) {
-                    view.style.opacity = owner.style.opacity;
+                    view.style.opacity = style.opacity;
                 }
 
                 (view as any).isHintViewIn = false;

--- a/drop-down.ios.ts
+++ b/drop-down.ios.ts
@@ -31,7 +31,6 @@ import * as utils from "utils/utils";
 import { SelectedIndexChangedEventData } from ".";
 import {
     DropDownBase,
-    DropDownListBase,
     Length,
     backgroundColorProperty,
     colorProperty,
@@ -50,27 +49,6 @@ export * from "./drop-down-common";
 
 const TOOLBAR_HEIGHT = 44;
 const HINT_COLOR = new Color("#3904041E");
-
-export class DropDownList extends DropDownListBase {
-    public _listPicker: UIPickerView; 
-    public [colorProperty.setNative](value: Color | UIColor) {
-        const color = value instanceof Color ? value.ios : value;
-
-        this.nativeView.color = color;
-        this._listPicker.tintColor = color;
-    }
-
-    public [backgroundColorProperty.setNative](value: Color | UIColor) {
-        if (!value) {
-            return;
-        }
-        
-        const color = value instanceof Color ? value.ios : value;
-        
-        this.nativeView.backgroundColor = color;
-        this._listPicker.backgroundColor = color;
-    }
-}
 
 export class DropDown extends DropDownBase {
     public _listPicker: UIPickerView;
@@ -108,13 +86,6 @@ export class DropDown extends DropDownBase {
         nsArray.addObject(this._flexToolbarSpace);
         nsArray.addObject(this._doneButton);
         this._toolbar.setItemsAnimated(nsArray, false);
-    }
-
-    public _addChildFromBuilder(name: string, value: any): void {
-        if (name === "DropDownList") {
-            this.dropDownList = value;
-            (value as DropDownList)._listPicker = this._listPicker;
-        }
     }
 
     public disposeNativeView() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-drop-down",
-  "version": "4.0.1",
+  "version": "5.0.1",
   "description": "A NativeScript DropDown widget.",
   "main": "drop-down",
   "typings": "drop-down.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-drop-down",
-  "version": "5.0.1",
+  "version": "5.0.0",
   "description": "A NativeScript DropDown widget.",
   "main": "drop-down",
   "typings": "drop-down.d.ts",


### PR DESCRIPTION
This is sort of a request for feedback rather than a ready-to-merge since I'm pretty new to NativeScript plugins.

It's an attempt at implementing #142 to style the selected item and the list items separately:

![image](https://user-images.githubusercontent.com/9100419/47921586-e2a30d80-df04-11e8-9d55-996af20723d6.png)

![screenshot_1541169484](https://user-images.githubusercontent.com/9100419/47921633-fa7a9180-df04-11e8-9e93-2f68a58fb643.png)

If this does get released I'd suggest doing so as a breaking change release as anyone using this is probably expecting matching styles but now a `<DropDownList>` child of `<DropDown>` is required to style the actual list items.
