### PR TITLE
Replace short imports with long ones

### DIFF
--- a/drop-down-common.ts
+++ b/drop-down-common.ts
@@ -13,14 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import { ObservableArray } from "data/observable-array";
-import { CSSType, CoercibleProperty, EventData, Property, View } from "ui/core/view";
-import { addWeakEventListener, removeWeakEventListener } from "ui/core/weak-event-listener";
-import { ItemsSource } from "ui/list-picker";
-import * as types from "utils/types";
+import { ObservableArray } from "tns-core-modules/data/observable-array";
+import { CSSType, CoercibleProperty, EventData, Property, View } from "tns-core-modules/ui/core/view";
+import { addWeakEventListener, removeWeakEventListener } from "tns-core-modules/ui/core/weak-event-listener";
+import { ItemsSource } from "tns-core-modules/ui/list-picker";
+import * as types from "tns-core-modules/utils/types";
 import { DropDown as DropDownDefinition, SelectedIndexChangedEventData, ValueItem, ValueList as ValueListDefinition } from ".";
 
-export * from "ui/core/view";
+export * from "tns-core-modules/ui/core/view";
 
 @CSSType("DropDown")
 export abstract class DropDownBase extends View implements DropDownDefinition {

--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -13,12 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import { Color } from "color";
-import { View } from "ui/core/view";
-import { Label } from "ui/label";
-import { StackLayout } from "ui/layouts/stack-layout";
-import { ItemsSource } from "ui/list-picker";
-import { Font } from "ui/styling/font";
+import { Color } from "tns-core-modules/color";
+import { View } from "tns-core-modules/ui/core/view";
+import { Label } from "tns-core-modules/ui/label";
+import { StackLayout } from "tns-core-modules/ui/layouts/stack-layout";
+import { ItemsSource } from "tns-core-modules/ui/list-picker";
+import { Font } from "tns-core-modules/ui/styling/font";
 import {
     TextAlignment,
     TextDecoration,
@@ -26,8 +26,8 @@ import {
     fontSizeProperty,
     textAlignmentProperty,
     textDecorationProperty
-} from "ui/text-base";
-import * as types from "utils/types";
+} from "tns-core-modules/ui/text-base";
+import * as types from "tns-core-modules/utils/types";
 import { SelectedIndexChangedEventData } from ".";
 import {
     DropDownBase,

--- a/drop-down.d.ts
+++ b/drop-down.d.ts
@@ -13,10 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import { ObservableArray } from "data/observable-array";
-import { CoercibleProperty, EventData, Property, View } from "ui/core/view";
-import { GestureTypes } from "ui/gestures/gestures";
-import { ItemsSource } from "ui/list-picker";
+import { ObservableArray } from "tns-core-modules/data/observable-array";
+import { CoercibleProperty, EventData, Property, View } from "tns-core-modules/ui/core/view";
+import { GestureTypes } from "tns-core-modules/ui/gestures/gestures";
+import { ItemsSource } from "tns-core-modules/ui/list-picker";
 
 export interface SelectedIndexChangedEventData extends EventData {
     oldIndex: number;

--- a/drop-down.ios.ts
+++ b/drop-down.ios.ts
@@ -13,10 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import { Color } from "color";
-import { ItemsSource } from "ui/list-picker";
-import { Font } from "ui/styling/font";
-import { Style } from "ui/styling/style";
+import { Color } from "tns-core-modules/color";
+import { ItemsSource } from "tns-core-modules/ui/list-picker";
+import { Font } from "tns-core-modules/ui/styling/font";
+import { Style } from "tns-core-modules/ui/styling/style";
 import {
     TextAlignment,
     TextDecoration,
@@ -25,9 +25,9 @@ import {
     textAlignmentProperty,
     textDecorationProperty,
     textTransformProperty
-} from "ui/text-base";
-import * as types from "utils/types";
-import * as utils from "utils/utils";
+} from "tns-core-modules/ui/text-base";
+import * as types from "tns-core-modules/utils/types";
+import * as utils from "tns-core-modules/utils/utils";
 import { SelectedIndexChangedEventData } from ".";
 import {
     DropDownBase,


### PR DESCRIPTION
Short imports were deprecated in NativeScript 5.2 (https://www.nativescript.org/blog/say-goodbye-to-short-imports-in-nativescript). This PR updates the imports to maintain compatibility.


Fixes #198 