### PR TITLE
Address Typings error when creating a new ValueList

### DIFF
--- a/drop-down.d.ts
+++ b/drop-down.d.ts
@@ -54,6 +54,7 @@ export  class ValueList<T> extends ObservableArray<ValueItem<T>> implements Item
     public getDisplay(index: number): string;
     public getValue(index: number): T;
     public getIndex(value: T): number;
+    constructor(items: ValueItem<T>[]);
 }
 
 export const selectedIndexProperty: CoercibleProperty<DropDown, number>;

--- a/drop-down.d.ts
+++ b/drop-down.d.ts
@@ -54,7 +54,9 @@ export  class ValueList<T> extends ObservableArray<ValueItem<T>> implements Item
     public getDisplay(index: number): string;
     public getValue(index: number): T;
     public getIndex(value: T): number;
+    
     constructor(items: ValueItem<T>[]);
+    constructor();
 }
 
 export const selectedIndexProperty: CoercibleProperty<DropDown, number>;


### PR DESCRIPTION
I've been getting a typing error when creating value lists with version 5.0+. Typescript has been complaining that the ValueList doesn't take any parameters for the constructor even though the code works fine. By adding the items value item to the constructor it addresses this issue.

I believe this should resolve some if not all of the issues reported in #205 