### PR TITLE
Add ability to change the placeholder color

### DIFF
--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -15,6 +15,7 @@ limitations under the License.
 ***************************************************************************** */
 import { Color } from "color";
 import { View } from "ui/core/view";
+import { placeholderColorProperty } from "ui/editable-text-base/editable-text-base";
 import { Label } from "ui/label";
 import { StackLayout } from "ui/layouts/stack-layout";
 import { ItemsSource } from "ui/list-picker";
@@ -27,7 +28,6 @@ import {
     textAlignmentProperty,
     textDecorationProperty
 } from "ui/text-base";
-import { placeholderColorProperty } from 'ui/editable-text-base/editable-text-base'
 import * as types from "utils/types";
 import { SelectedIndexChangedEventData } from ".";
 import {
@@ -227,7 +227,7 @@ export class DropDown extends DropDownBase {
                     if (property === "textAlignment" || property === "textDecoration"
                         || property === "fontInternal" || property === "fontSize"
                         || property === "color"
-                        || property === 'placeholderColor') {
+                        || property === "placeholderColor") {
                         const label = view.getViewById<Label>(LABELVIEWID);
                         label.style[property] = value;
                     }

--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -27,6 +27,7 @@ import {
     textAlignmentProperty,
     textDecorationProperty
 } from "ui/text-base";
+import { placeholderColorProperty } from 'ui/editable-text-base/editable-text-base'
 import * as types from "utils/types";
 import { SelectedIndexChangedEventData } from ".";
 import {
@@ -188,6 +189,10 @@ export class DropDown extends DropDownBase {
         }
     }
 
+    public [placeholderColorProperty.setNative](value: Color | number) {
+        this._propagateStylePropertyToRealizedViews("placeholderColor", value, true);
+    }
+
     public _getRealizedView(convertView: android.view.View, realizedViewType: RealizedViewType): View {
         if (!convertView) {
             const view = new Label();
@@ -221,7 +226,8 @@ export class DropDown extends DropDownBase {
                 if (isIncludeHintIn || !(view as any).isHintViewIn) {
                     if (property === "textAlignment" || property === "textDecoration"
                         || property === "fontInternal" || property === "fontSize"
-                        || property === "color") {
+                        || property === "color"
+                        || property === 'placeholderColor') {
                         const label = view.getViewById<Label>(LABELVIEWID);
                         label.style[property] = value;
                     }
@@ -399,6 +405,9 @@ function initializeDropDownAdapter() {
                 if (owner.style.color) {
                     label.style.color = owner.style.color;
                 }
+                if (owner.style.placeholderColor) {
+                    label.style.placeholderColor = owner.style.placeholderColor;
+                }
                 label.style.textDecoration = owner.style.textDecoration;
                 label.style.textAlignment = owner.style.textAlignment;
                 label.style.fontInternal = owner.style.fontInternal;
@@ -417,7 +426,11 @@ function initializeDropDownAdapter() {
 
                 // Hint View styles
                 if (index === 0) {
-                    label.style.color = new Color(255, 148, 150, 148);
+                    if (label.style.placeholderColor) {
+                        label.style.color = label.style.placeholderColor;
+                    } else {
+                        label.style.color = new Color(255, 148, 150, 148);
+                    }
                     (view as any).isHintViewIn = true;
 
                     // HACK: if there is no hint defined, make the view in the drop down virtually invisible.

--- a/drop-down.ios.ts
+++ b/drop-down.ios.ts
@@ -26,6 +26,7 @@ import {
     textDecorationProperty,
     textTransformProperty
 } from "ui/text-base";
+import { placeholderColorProperty } from 'ui/editable-text-base/editable-text-base'
 import * as types from "utils/types";
 import * as utils from "utils/utils";
 import { SelectedIndexChangedEventData } from ".";
@@ -199,6 +200,15 @@ export class DropDown extends DropDownBase {
         this.nativeView.color = color;
         this._listPicker.tintColor = color;
         this._listPicker.reloadAllComponents();
+    }
+
+    public [placeholderColorProperty.getDefault](): UIColor {
+        return this.nativeView.placeholderColor;
+    }
+    public [placeholderColorProperty.setNative](value: Color | UIColor) {
+        const color = value instanceof Color ? value.ios : value;
+
+        this.nativeView.placeholderColor = color;
     }
 
     public [backgroundColorProperty.getDefault](): UIColor {
@@ -397,6 +407,7 @@ class TNSDropDownLabel extends TNSLabel {
         label._owner = owner;
         label._isInputViewOpened = false;
         label.color = utils.ios.getter(UIColor, UIColor.blackColor);
+        label.placeholderColor = HINT_COLOR.ios;
         label.text = " "; // HACK: Set the text to space so that it takes the necessary height if no hint/selected item
 
         label.addGestureRecognizer(UITapGestureRecognizer.alloc().initWithTargetAction(label, "tap"));
@@ -411,6 +422,7 @@ class TNSDropDownLabel extends TNSLabel {
     private _hint: string;
     private _hasText: boolean;
     private _internalColor: UIColor;
+    private _internalPlaceholderColor: UIColor;
 
     get inputView(): UIView {
         return this._inputView;
@@ -452,6 +464,14 @@ class TNSDropDownLabel extends TNSLabel {
     }
     set color(value: UIColor) {
         this._internalColor = value;
+        this._refreshColor();
+    }
+
+    get placeholderColor(): UIColor {
+        return this._internalPlaceholderColor;
+    }
+    set placeholderColor(value: UIColor) {
+        this._internalPlaceholderColor = value;
         this._refreshColor();
     }
 
@@ -514,7 +534,7 @@ class TNSDropDownLabel extends TNSLabel {
     }
 
     private _refreshColor() {
-        this.textColor = (this._hasText && this._internalColor ? this._internalColor : HINT_COLOR.ios);
+        this.textColor = (this._hasText ? this._internalColor : this._internalPlaceholderColor);
     }
 }
 

--- a/drop-down.ios.ts
+++ b/drop-down.ios.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
 import { Color } from "color";
+import { placeholderColorProperty } from "ui/editable-text-base/editable-text-base";
 import { ItemsSource } from "ui/list-picker";
 import { Font } from "ui/styling/font";
 import { Style } from "ui/styling/style";
@@ -26,7 +27,6 @@ import {
     textDecorationProperty,
     textTransformProperty
 } from "ui/text-base";
-import { placeholderColorProperty } from 'ui/editable-text-base/editable-text-base'
 import * as types from "utils/types";
 import * as utils from "utils/utils";
 import { SelectedIndexChangedEventData } from ".";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-drop-down",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "A NativeScript DropDown widget.",
   "main": "drop-down",
   "typings": "drop-down.d.ts",


### PR DESCRIPTION
Hello

This pull request adds the ability to change the hint color using placeholder-color from `tns-core-modules/ui/editable-text-base/editable-text-base`

Closes #55 

Tested on both Android and iOS

I'm pretty new to Nativescript _and_ Typescript, so please forgive me if I've done anything wrong.