### PR TITLE
utils.ios.getter() is deprecated; use the respective native property …

### DIFF
--- a/drop-down.ios.ts
+++ b/drop-down.ios.ts
@@ -28,7 +28,6 @@ import {
     textTransformProperty
 } from "ui/text-base";
 import * as types from "utils/types";
-import * as utils from "utils/utils";
 import { SelectedIndexChangedEventData } from ".";
 import {
     DropDownBase,
@@ -78,7 +77,7 @@ export class DropDown extends DropDownBase {
         super.initNativeView();
 
         const nativeView: TNSDropDownLabel = this.nativeViewProtected;
-        var applicationFrame = UIApplication.sharedApplication.keyWindow.frame;
+        const applicationFrame = UIApplication.sharedApplication.keyWindow.frame;
         
         this._listPicker = UIPickerView.alloc().init();
 

--- a/drop-down.ios.ts
+++ b/drop-down.ios.ts
@@ -78,7 +78,7 @@ export class DropDown extends DropDownBase {
         super.initNativeView();
 
         const nativeView: TNSDropDownLabel = this.nativeViewProtected;
-        const applicationFrame = utils.ios.getter(UIScreen, UIScreen.mainScreen).applicationFrame;
+        var applicationFrame = UIApplication.sharedApplication.keyWindow.frame;
         
         this._listPicker = UIPickerView.alloc().init();
 
@@ -461,7 +461,7 @@ class TNSDropDownLabel extends TNSLabel {
 
         label._owner = owner;
         label._isInputViewOpened = false;
-        label.color = utils.ios.getter(UIColor, UIColor.blackColor);
+        label.color = UIColor.blackColor;
         label.placeholderColor = HINT_COLOR.ios;
         label.text = " "; // HACK: Set the text to space so that it takes the necessary height if no hint/selected item
         label.addGestureRecognizer(UITapGestureRecognizer.alloc().initWithTargetAction(label, "tap"));


### PR DESCRIPTION
This pull requests removes the following deprecated warning:

```
CONSOLE LOG file:///node_modules/@nativescript/core/utils/native-helper.js:24:0: utils.ios.getter() is deprecated; use the respective native property instead
CONSOLE LOG file:///node_modules/@nativescript/core/utils/native-helper.js:24:0: utils.ios.getter() is deprecated; use the respective native property instead
```
