### PR TITLE
fix issue android closed event

### DIFF
--- a/drop-down.android.ts
+++ b/drop-down.android.ts
@@ -336,6 +336,7 @@ function initializeTNSSpinner() {
                     eventName: DropDownBase.closedEvent,
                     object: owner
                 });
+                this._isOpenedIn = false;
             }
         }
 


### PR DESCRIPTION
#242 fix this.

## Origin issue root cause

`_isOpenedIn` is set in function `performClick`, but is not set to false anywhere.

In fact, it should be set to false when we are closed.